### PR TITLE
using SCORE_PUBLISHED signal to generate gradebook

### DIFF
--- a/gradebook/signals.py
+++ b/gradebook/signals.py
@@ -8,7 +8,7 @@ from django.dispatch import receiver
 from django.conf import settings
 from django.db.models.signals import post_save, pre_save
 
-from openedx.core.djangoapps.signals.signals import COURSE_GRADE_CHANGED
+from lms.djangoapps.grades.signals.signals import SCORE_PUBLISHED
 from util.signals import course_deleted
 from student.roles import get_aggregate_exclusion_user_ids
 from edx_notifications.lib.publisher import (
@@ -25,10 +25,10 @@ from gradebook.tasks import update_user_gradebook
 log = logging.getLogger(__name__)
 
 
-@receiver(COURSE_GRADE_CHANGED)
-def on_course_grade_changed(sender, user, course_grade, course_key, deadline, **kwargs):  # pylint: disable=unused-argument
+@receiver(SCORE_PUBLISHED)
+def on_course_grade_published(sender, user, course_grade, course_key, deadline, **kwargs):  # pylint: disable=unused-argument
     """
-    Listens for a 'COURSE_GRADE_CHANGED' signal invoke grade book update task
+    Listens for a 'SCORE_PUBLISHED' signal invoke grade book update task
     """
     user_id = user.id
     course_key = unicode(course_key)

--- a/gradebook/utils.py
+++ b/gradebook/utils.py
@@ -3,9 +3,7 @@ Utils methods for gradebook app
 """
 import json
 
-from django.db import transaction
 from django.utils import timezone
-from django.utils.decorators import method_decorator
 
 from xmodule.modulestore import EdxJSONEncoder
 from xmodule.modulestore.django import modulestore
@@ -15,7 +13,6 @@ from courseware.courses import get_course
 from gradebook.models import StudentGradebook
 
 
-@method_decorator(transaction.non_atomic_requests)
 def generate_user_gradebook(course_key, user):
     """
     Recalculates the specified user's gradebook entry
@@ -57,7 +54,7 @@ def generate_user_gradebook(course_key, user):
 
 def get_json_data(obj):
     try:
-        json_data = json.dumps(obj, cls=GradeJSONEncoder)
+        json_data = json.dumps(obj, cls=EdxJSONEncoder)
     except:
         json_data = {}
     return json_data
@@ -98,20 +95,6 @@ def make_courseware_summary(chapter_grades):
             'sections': sub_sections,
         })
     return courseware_summary
-
-
-class GradeJSONEncoder(EdxJSONEncoder):
-    """
-    Custom JSONEncoder that handles `Location` and `datetime.datetime` objects.
-
-    `Location`s are encoded as their url string form, and `datetime`s as
-    ISO date strings
-    """
-    def default(self, obj):
-        if isinstance(obj, SubsectionGrade):
-            return obj.dict()
-        else:
-            return super(EdxJSONEncoder, self).default(obj)
 
 
 def calculate_proforma_grade(course_grade, grading_policy):


### PR DESCRIPTION
using SCORE_PUBLISHED signal to generate gradebook to avoid recursion errors and remove unnecessary GradeJSONEncoder.