### PR TITLE
MCKIN-9213: invalidate gradebook cache on post_save signal

### DIFF
--- a/gradebook/signals.py
+++ b/gradebook/signals.py
@@ -16,7 +16,7 @@ from edx_notifications.lib.publisher import (
 )
 from edx_notifications.data import NotificationMessage
 from edx_solutions_api_integration.utils import (
-    get_aggregate_exclusion_user_ids,
+    get_aggregate_exclusion_user_ids, invalid_user_data_cache,
 )
 
 from gradebook.models import StudentGradebook, StudentGradebookHistory
@@ -77,6 +77,7 @@ def handle_studentgradebook_post_save_signal(sender, instance, **kwargs):
     """
     Handle the pre-save ORM event on CourseModuleCompletions
     """
+    invalid_user_data_cache('grade', instance.course_id, instance.user.id)
 
     if settings.FEATURES['ENABLE_NOTIFICATIONS']:
         # attach the rank of the user before the save is completed

--- a/gradebook/utils.py
+++ b/gradebook/utils.py
@@ -8,9 +8,6 @@ from xmodule.modulestore import EdxJSONEncoder
 from xmodule.modulestore.django import modulestore
 from lms.djangoapps.grades.new.course_grade_factory import CourseGradeFactory
 from courseware.courses import get_course
-from edx_solutions_api_integration.utils import (
-    invalid_user_data_cache,
-)
 from gradebook.models import StudentGradebook
 
 
@@ -57,7 +54,6 @@ def generate_user_gradebook(course_key, user):
         gradebook_entry.grading_policy = grading_policy
         gradebook_entry.is_passed = is_passed
         gradebook_entry.save()
-        invalid_user_data_cache('grade', course_key, user.id)
 
     return gradebook_entry
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='gradebook-edx-platform-extensions',
-    version='1.1.12',
+    version='1.1.13',
     description='User grade management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
This PR ensures that cache for user course grade is invalidated every time gradebook is updated, so user gets updated grades.

Test instructions:
1. Create a new course shell and add a graded assessment to the course.
2. Enrol a user to the course and go to course dashboard with that user, proficiency should be 0.
3. Attempt the assessment and go to course dashboard and proficiency score should be updated as per your grade and same should be reflected on the progress page.