### PR TITLE
Change method name of course Gradefactory.

### DIFF
--- a/gradebook/utils.py
+++ b/gradebook/utils.py
@@ -20,7 +20,7 @@ def generate_user_gradebook(course_key, user):
     """
     with modulestore().bulk_operations(course_key):
         course_descriptor = get_course(course_key, depth=None)
-        course_grade = CourseGradeFactory().create(user, course_descriptor)
+        course_grade = CourseGradeFactory().read(user, course_descriptor)
         grade_summary = course_grade.summary
         is_passed = course_grade.passed
         progress_summary = make_courseware_summary(course_grade)


### PR DESCRIPTION
CourseGradeFactory `create` renamed to the `read` method in this commit  

[Grades cleanup: remove read_only param and create method](http://github.com/edx/edx-platform/commit/1febdbfac940bc7b0d356d9ea75de0cb642584e3#diff-4e12517c08209a845f79dad833bd9cb4R23)