### PR TITLE
MCKIN-30997 - In case of tie in user proficiency scores, sorting user position by modified date

### DIFF
--- a/gradebook/models.py
+++ b/gradebook/models.py
@@ -158,7 +158,7 @@ class StudentGradebook(models.Model):
 
         if user_queryset:
             user_grade = user_queryset.grade
-            user_time_scored = user_queryset.created
+            user_time_scored = user_queryset.modified
 
         queryset = cls._build_queryset(course_key, **kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='gradebook-edx-platform-extensions',
-    version='3.0.0',
+    version='3.0.1',
     description='User grade management extension for edX platform',
     long_description=open('README.rst').read(),
     author='edX',


### PR DESCRIPTION
In case there is a tie in user proficiency scores, they are further sorted on the basis of their `modified date` in leader board. However they are being sorted on the basis of `created date` while calculating user position. Changing this behavior to use `modified date` as sorting criteria instead of `created date` while calculating user position.